### PR TITLE
chore(deps): update dependency semver to v7.5.4

### DIFF
--- a/plugins/node/opentelemetry-instrumentation-dns/package.json
+++ b/plugins/node/opentelemetry-instrumentation-dns/package.json
@@ -64,7 +64,7 @@
   "dependencies": {
     "@opentelemetry/instrumentation": "^0.41.2",
     "@opentelemetry/semantic-conventions": "^1.0.0",
-    "semver": "^7.3.2"
+    "semver": "^7.5.4"
   },
   "homepage": "https://github.com/open-telemetry/opentelemetry-js-contrib/tree/main/plugins/node/opentelemetry-instrumentation-dns#readme"
 }


### PR DESCRIPTION
## Which problem is this PR solving?

- This PR updates semver version in [opentelemetry-instrumentation-dns](https://github.com/open-telemetry/opentelemetry-js-contrib/blob/main/plugins/node/opentelemetry-instrumentation-dns/package.json#L67) in order to fix https://security.snyk.io/vuln/SNYK-JS-SEMVER-3247795

## Short description of the changes

- After this PR, the version for semver will be upgraded & aligned with other opentelemetry packages in this monorepo.
